### PR TITLE
Added sys.arg, multiple file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 ## Steps to run:
 1. Download this code by clicking the green coloured download code button above and clicking download zip, and unzip it to your required location.
-2. Copy your certificate to this location. Make sure the name of the file is "certificate.pdf". You can also edit the code to accept any other file name. 
+2. Copy your certificates to this location. If you want to edit just one pdf,  pass the name of the certificate as an argument. For multiple pdfs at once, pass 'a' or 'all' as argument. If you don't want to use arguments, ensure the name of the file is "certificate.pdf".
 3. Install python from https://www.python.org/downloads/ (I ran it using version 3.9, it should work normally on any other version as well)
-4. Install pdf2image module using `pip install pdf2image`. It requires poppler as described [here](https://github.com/Belval/pdf2image).
+4. Install pdf2image and PIL modules using `pip install -r requirements.txt`.
+5. pdf2image requires poppler as described [here](https://github.com/Belval/pdf2image).
    Once installed, set the path of poppler in the poppler_path variable in pdfedit.py.
-4. Install PIL module using `pip install pillow`. 
-5. Run the code from commandline using `python pdfedit.py`. 
+5. Install PIL module using `pip install `. 
+6. Run the code from commandline using `python pdfedit.py` with a subsequent argument as described in step 2. 
 
 The result should look like below:
 ![result image](https://raw.githubusercontent.com/gloriousalbus/pdfedit/main/res.jpg)

--- a/pdfedit.py
+++ b/pdfedit.py
@@ -1,43 +1,79 @@
 from pdf2image import convert_from_path, convert_from_bytes
 from PIL import Image
 import os
+import sys
+poppler_path = r"C:\pdfedit-main\poppler-21.03.0\Library\bin"
 
-poppler_path = r"E:\user\Release-21.03.0\poppler-21.03.0\Library\bin"
-certificate_file = 'certificate.pdf'
+# if you want to edit all pdfs together, use 'python pdfedit.py a' or 'all', else 'python pdfedit.py certificatename.py'
+def getcertificatenames():
+	certificates = list()
+	if len(sys.argv) == 2:
+		if sys.argv[1] == 'a' or sys.argv[1] == 'all':
+			for file in os.listdir("./"):
+				if file.split('.')[-1] == 'pdf':
+					certificates.append(file)
+		else:
+			try:
+				splitname = sys.argv[1].split('.')
+				if len(splitname) >= 2:
+					if splitname[-1] == 'pdf':
+						print("pdf")
+						certificates.append(sys.argv[1])
+			except:
+				certificates.append('certificate.pdf')
+	else:
+		certificates.append('certificate.pdf')
+	return certificates
+
+certificates = getcertificatenames()
+print(f"Number of pdfs found: {len(certificates)}")
 image_file = 'out.jpg'
 
-#obtain a jpg image from the pdf
-images = convert_from_path(certificate_file, poppler_path = poppler_path)
-images[0].save(image_file, 'JPEG')
+# make 'edited' directory as destination
+if not os.path.exists('edited'):
+    os.makedirs('edited')
 
-#open the converted image and the flag image using PIL module 
-img = Image.open(image_file)
-flag = Image.open('flag.jpg')
+#open the flag image using PIL module 
+with Image.open('flag.jpg') as flag:
+	
+	for certificate in certificates:
+		print(certificate, end="\t")
 
-#load the pixel map of the certificate
-pixels = img.load()
+		#obtain a jpg image from the pdf
+		images = convert_from_path(certificate, poppler_path = poppler_path)
+		images[0].save(image_file, 'JPEG')
 
-#replacement colour
-colour = (232,236,239)
+		#open the converted image using PIL module 
+		with Image.open(image_file) as img:
+			
+			#load the pixel map of the certificate
+			pixels = img.load()
 
-#colour over with background colour
-for i in range(0, 950):
-	for j in range(1616, 1950):
-		if i not in range(837, 886) or j not in range(1606, 1656):
-			img.putpixel((i,j), colour)
+			#replacement colour
+			colour = (232,236,239)
 
-#insert flag
-img.paste(flag, (180, 1616))
+			#colour over with background colour
+			for i in range(0, 950):
+				for j in range(1616, 1950):
+					if i not in range(837, 886) or j not in range(1606, 1656):
+						img.putpixel((i,j), colour)
 
-#display result
-img.show()
+			#insert flag
+			img.paste(flag, (180, 1616))
 
-#remove temporary file
-os.remove(image_file)
+			#display result, only if amending one certificate
+			if len(certificates) == 1:
+				img.show()
 
-#save result as pdf
-img.save('certificate_edited.pdf', 'PDF' ,resolution=100.0)
+			#remove temporary file
+			os.remove(image_file)
+			
+			# savename is filename_edited
+			savename = os.path.splitext(certificate)[0]
 
-#close the files
-img.close()
-flag.close()
+			#save result as pdf
+			img.save(f'./edited/{savename}_edited.pdf', 'PDF' ,resolution=100.0)
+			
+			print("Done")
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pdf2image
+pillow


### PR DESCRIPTION
This pull allows the user to edit multiple pdfs all at once. 
sys.arg being 'a', or 'all' lets the script know there may be multple files to edit.
Argument being 'certificate_name.pdf' lets the script know the name of the file to target.

It'll make a list of all pdf files in the directory, 
All edited files will be exported to './edited/' directory

