### PR TITLE
Update pdfedit.py

### DIFF
--- a/pdfedit.py
+++ b/pdfedit.py
@@ -2,7 +2,7 @@ from pdf2image import convert_from_path, convert_from_bytes
 from PIL import Image
 import os
 
-poppler_path = r"E:\user\Release-21.03.0\poppler-21.03.0\Library\bin"
+poppler_path = input("Enter the path of to the bin folder of poppler: ")
 certificate_file = 'certificate.pdf'
 image_file = 'out.jpg'
 


### PR DESCRIPTION
User can now input their Poppler path in the beginning, which was leading to an error for some people who extracted the file in other locations (different from the one in the code)